### PR TITLE
Add README for OctoAcme Project Management Docs with process summary and links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+# OctoAcme Project Management Documentation
+
+This folder contains OctoAcme's project management process documentation. The README provides a high-level overview of the processes, expectations, and how to navigate the full set of project management docs.
+
+## OctoAcme Project Management Processes
+
+OctoAcme uses a structured project management approach with clearly defined phases and supporting practices:
+
+- **Initiation**: Define project objectives, scope, stakeholders, and expected outcomes. This sets the foundation for alignment and initial governance.
+- **Planning**: Develop detailed schedules, resource plans, requirements, risk planning, and communication strategies to guide execution.
+- **Execution and Tracking**: Carry out work against the plan while tracking progress, managing scope, monitoring issues, and reporting status.
+- **Risks and Communication**: Identify and manage project risks, escalate when needed, and keep stakeholders informed through proactive communication.
+- **Release and Deployment**: Coordinate deployment activities, validate readiness, and ensure a safe transition from execution to production or delivery.
+- **Retrospective and Continuous Improvement**: Capture lessons learned, review outcomes, and refine processes to improve future projects.
+- **Roles and Personas**: Clarify team roles, responsibilities, and stakeholder expectations so everyone understands how they contribute to project success.
+
+## Docs in this Folder
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution and Tracking](octoacme-execution-and-tracking.md)
+- [Risks and Communication](octoacme-risks-and-communication.md)
+- [Release and Deployment](octoacme-release-and-deployment.md)
+- [Retrospective and Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)
+
+## How to Use This README
+
+Start here to understand the overall OctoAcme project management approach, then follow the links to explore each detailed process document. The README is intended as a central entry point for onboarding, review, and cross-document navigation.


### PR DESCRIPTION
This pull request adds a new `docs/README.md` that provides a concise overview of OctoAcme project management processes and direct links to all project management docs in the `docs/` folder.

Closes #2